### PR TITLE
Badges and other improvements to members

### DIFF
--- a/_collections/members/agarzola.md
+++ b/_collections/members/agarzola.md
@@ -8,4 +8,6 @@ profiles:
   bitbucket: agarzola
   twitter: agarzola
   linkedin: agarzola
+roles:
+  - contributor
 ---

--- a/_collections/members/bobby_brb3.md
+++ b/_collections/members/bobby_brb3.md
@@ -7,4 +7,6 @@ profiles:
   github: brb3
   twitter: bobbyrburden
   linkedin: bobbyrburden
+roles:
+- contributor
 ---

--- a/_collections/members/digdog.md
+++ b/_collections/members/digdog.md
@@ -3,4 +3,6 @@ name: Thomas Krause
 gravatar: fef4e9f88ed6187a0cd645a678d9e09a
 profiles:
   github: digtk
+roles:
+- contributor
 ---

--- a/_collections/members/patriotbob.md
+++ b/_collections/members/patriotbob.md
@@ -7,4 +7,6 @@ profiles:
   twitter: patriotbob83
   linkedin: zech-sloan-8a77717b
   stackoverflow: 1246014
+roles:
+  - contributor
 ---

--- a/_collections/members/ryanmaynard.md
+++ b/_collections/members/ryanmaynard.md
@@ -9,5 +9,5 @@ profiles:
   linkedin: boryanmaynard
 roles:
   - contributor
-  - blogger
+  - writer
 ---

--- a/_collections/members/ryanmaynard.md
+++ b/_collections/members/ryanmaynard.md
@@ -7,4 +7,7 @@ profiles:
   gitlab: ryanmaynard
   twitter: ryanmaynard00
   linkedin: boryanmaynard
+roles:
+  - contributor
+  - blogger
 ---

--- a/_collections/members/strangewill.md
+++ b/_collections/members/strangewill.md
@@ -10,4 +10,6 @@ profiles:
   twitter: strangewill
   linkedin: williamroush
   stackoverflow: 713907
+roles:
+  - contributor
 ---

--- a/_collections/members/t-richards.md
+++ b/_collections/members/t-richards.md
@@ -7,4 +7,6 @@ profiles:
   twitter: the_tomrichards
   linkedin: thomasdrichards
   stackoverflow: 609053
+roles:
+  - contributor
 ---

--- a/_includes/member.html
+++ b/_includes/member.html
@@ -1,53 +1,55 @@
 <li id="{{member.slug}}" class="member">
-  {% if member.website %}
-  <a href="{{member.website}}" title="{{member.name}}’s website" class="website">
-  {% endif %}
-    <img src="https://s.gravatar.com/avatar/{{ member.gravatar }}?s=160&r=g" alt="{{ member.name }}’s profile picture" />
-    <h3 class="member--name">{{ member.name }}</h3>
-  {% if member.website %}
-  </a>
-  {% endif %}
+  <div class="member--wrapper">
+    {% if member.website %}
+    <a href="{{member.website}}" title="{{member.name}}’s website" class="website">
+    {% endif %}
+      <img src="https://s.gravatar.com/avatar/{{ member.gravatar }}?s=160&r=g" alt="{{ member.name }}’s profile picture" />
+      <h3 class="member--name">{{ member.name }}</h3>
+    {% if member.website %}
+    </a>
+    {% endif %}
 
-  {% if member.roles %}
-    <ul class="member--badges" aria-label="Roles">
-      {% for role in member.roles %}
+    {% if member.roles %}
+      <ul class="member--badges" aria-label="Roles">
+        {% for role in member.roles %}
+          <li>
+            <span class="member--badge {{ role | slugify }}">{{ role | truncate: 1, "" }}<span class="rest">{{ role | slice: 1, 100 }}</span></span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if member.profiles %}
+      <ul class="member--links" aria-label="Profile Links">
+        {% for profile in member.profiles %}
         <li>
-          <span class="member--badge {{ role | slugify }}">{{ role | truncate: 1, "" }}<span class="rest">{{ role | slice: 1, 100 }}</span></span>
+          {% if profile[0] == 'twitter' %}
+            <a href="https://twitter.com/{{profile[1]}}" title="{{member.name}} on Twitter" class="twitter">Twitter</a>
+
+          {% elsif profile[0] == 'github' %}
+            <a href="https://github.com/{{profile[1]}}" title="{{member.name}} on Github" class="github">Github</a>
+
+          {% elsif profile[0] == 'gitlab' %}
+            <a href="https://gitlab.com/{{profile[1]}}" title="{{member.name}} on Gitlab" class="gitlab">Gitlab</a>
+
+          {% elsif profile[0] == 'bitbucket' %}
+            <a href="https://bitbucket.org/{{profile[1]}}" title="{{member.name}} on Bitbucket" class="bitbucket">Bitbucket</a>
+
+          {% elsif profile[0] == 'linkedin' %}
+            <a href="https://linkedin.com/in/{{profile[1]}}" title="{{member.name}} on LinkedIn" class="linkedin">LinkedIn</a>
+
+          {% elsif profile[0] == 'stackoverflow' %}
+            <a href="https://stackoverflow.com/users/{{profile[1]}}" title="{{member.name}} on Stack Overflow" class="stackoverflow">Stack Overflow</a>
+
+          {% elsif profile[0] == 'facebook' %}
+            <a href="https://facebook.com/{{profile[1]}}" title="{{member.name}} on Facebook" class="facebook">Facebook</a>
+
+          {% else %}
+            <a href="{{profile[1]}}" title="{{member.name}} on {{profile[0]}}" class="{{profile[0]}}">{{profile[0]}}</a>
+          {% endif %}
         </li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-
-  {% if member.profiles %}
-    <ul class="member--links" aria-label="Profile Links">
-      {% for profile in member.profiles %}
-      <li>
-        {% if profile[0] == 'twitter' %}
-          <a href="https://twitter.com/{{profile[1]}}" title="{{member.name}} on Twitter" class="twitter">Twitter</a>
-
-        {% elsif profile[0] == 'github' %}
-          <a href="https://github.com/{{profile[1]}}" title="{{member.name}} on Github" class="github">Github</a>
-
-        {% elsif profile[0] == 'gitlab' %}
-          <a href="https://gitlab.com/{{profile[1]}}" title="{{member.name}} on Gitlab" class="gitlab">Gitlab</a>
-
-        {% elsif profile[0] == 'bitbucket' %}
-          <a href="https://bitbucket.org/{{profile[1]}}" title="{{member.name}} on Bitbucket" class="bitbucket">Bitbucket</a>
-
-        {% elsif profile[0] == 'linkedin' %}
-          <a href="https://linkedin.com/in/{{profile[1]}}" title="{{member.name}} on LinkedIn" class="linkedin">LinkedIn</a>
-
-        {% elsif profile[0] == 'stackoverflow' %}
-          <a href="https://stackoverflow.com/users/{{profile[1]}}" title="{{member.name}} on Stack Overflow" class="stackoverflow">Stack Overflow</a>
-
-        {% elsif profile[0] == 'facebook' %}
-          <a href="https://facebook.com/{{profile[1]}}" title="{{member.name}} on Facebook" class="facebook">Facebook</a>
-
-        {% else %}
-          <a href="{{profile[1]}}" title="{{member.name}} on {{profile[0]}}" class="{{profile[0]}}">{{profile[0]}}</a>
-        {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
 </li>

--- a/_includes/member.html
+++ b/_includes/member.html
@@ -3,12 +3,23 @@
   <a href="{{member.website}}" title="{{member.name}}’s website" class="website">
   {% endif %}
     <img src="https://s.gravatar.com/avatar/{{ member.gravatar }}?s=160&r=g" alt="{{ member.name }}’s profile picture" />
-    <span class="member--name">{{ member.name }}</span>
+    <h3 class="member--name">{{ member.name }}</h3>
   {% if member.website %}
   </a>
   {% endif %}
+
+  {% if member.roles %}
+    <ul class="member--badges" aria-label="Roles">
+      {% for role in member.roles %}
+        <li>
+          <span class="member--badge {{ role | slugify }}">{{ role | truncate: 1, "" }}<span class="rest">{{ role | slice: 1, 100 }}</span></span>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
   {% if member.profiles %}
-    <ul class="member--links">
+    <ul class="member--links" aria-label="Profile Links">
       {% for profile in member.profiles %}
       <li>
         {% if profile[0] == 'twitter' %}

--- a/_pages/members.html
+++ b/_pages/members.html
@@ -31,3 +31,21 @@ menu_sort: 3
   {% endif %}
   {% endfor %}
 </ul>
+
+<script>
+  (function (window, document) {
+    var members = document.getElementsByClassName('member');
+    for (var i = members.length - 1; i >= 0; i--) {
+      members[i].addEventListener('focus', expand_badges, true);
+      members[i].addEventListener('blur', collapse_badges, true);
+      members[i].addEventListener('mouseover', expand_badges, true);
+      members[i].addEventListener('mouseout', collapse_badges, true);
+    }
+    function expand_badges () {
+      this.setAttribute('aria-expanded', true);
+    }
+    function collapse_badges () {
+      this.removeAttribute('aria-expanded', false);
+    }
+  })(window, document);
+</script>

--- a/_pages/members.html
+++ b/_pages/members.html
@@ -45,7 +45,7 @@ menu_sort: 3
       this.setAttribute('aria-expanded', true);
     }
     function collapse_badges () {
-      this.removeAttribute('aria-expanded', false);
+      this.removeAttribute('aria-expanded');
     }
   })(window, document);
 </script>

--- a/_pages/members.html
+++ b/_pages/members.html
@@ -16,10 +16,12 @@ menu_sort: 3
 {% endif %}
 {% endfor %}
   <li class="member you">
-    <a href="/slack">
-      <img src="/images/you.png" alt="You?">
-      <span class="member--name">Join us!</span>
-    </a>
+    <div class="member--wrapper">
+      <a href="/slack">
+        <img src="/images/you.png" alt="You?">
+        <span class="member--name">Join us!</span>
+      </a>
+    </div>
   </li>
 </ul>
 <hr>

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -67,9 +67,9 @@
   &:target {
     border: 4px solid $brand-color;
     box-sizing: border-box;
-    transform: scale((160/152)) rotate(-2deg);
+    transform: scale(1.1) rotate(-2deg);
     transform-origin: center center;
-    background-color: #ededed;
+    background-color: #fff;
     a.website::before {
       height: (152/$base-font-size)*1em;
     }

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -165,8 +165,8 @@
   text-align: right;
   text-transform: uppercase;
   font-weight: bold;
-  font-size: 0.7em;
-  letter-spacing: (1/$base-font-size) * 1em;
+  font-size: 0.8em;
+  letter-spacing: (1/($base-font-size * 0.8)) * 1em;
   line-height: 1.4em;
   color: white;
   position: absolute;
@@ -183,10 +183,11 @@
     }
   }
   .member--badge {
-    padding: 0.1em 0.4em 0.1em;
+    padding: 0.1em 0.35em 0;
     background-color: $grey-color;
     border-radius: 2px;
     border: 1px solid $grey-color-dark;
+    font-family: $mono-font-family;
     &.contributor {
       background-color: $blue-color;
     }

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -157,3 +157,58 @@
     clear: both;
   }
 }
+
+.member--badges {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  text-align: right;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 0.7em;
+  letter-spacing: (1/$base-font-size) * 1em;
+  line-height: 1.4em;
+  color: white;
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -3px;
+  pointer-events: none;
+  li {
+    display: block;
+    margin-top: 0;
+    margin-left: auto;
+    & + li {
+      margin-top: 4px;
+    }
+  }
+  .member--badge {
+    padding: 0.1em 0.4em 0.1em;
+    background-color: $grey-color;
+    border-radius: 2px;
+    border: 1px solid $grey-color-dark;
+    &.contributor {
+      background-color: $blue-color;
+    }
+    &.volunteer {
+      background-color: $yellow-color;
+    }
+    &.blogger {
+      background-color: $lilac-color;
+    }
+  }
+  .rest {
+    max-width: 0;
+    display: inline-block;
+    vertical-align: bottom;
+    overflow: hidden;
+    transition-property: max-width;
+  }
+  a:hover ~ &, a:focus ~ &,
+  img:hover ~ &, .member[aria-expanded="true"] & {
+    cursor: default;
+    .rest {
+      max-width: 90%;
+    }
+  }
+}

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -78,40 +78,20 @@
 
 .member--name {
   font-size: (14/$base-font-size)*1em;
+  font-weight: normal;
+  margin-top: 0;
   display: block;
   height: 1.4em;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   text-align: center;
-  // font-style: italic;
-  // left: 0;
-  // bottom: 0;
-  // padding: 0 0.4em;
-  // border: 2px solid $background-color;
-  // border-left: none;
-  // border-bottom: none;
-  // position: absolute;
-  // background-color: $text-color;
-  // background-color: rgba($text-color, 0.7);
-  // color: $background-color;
 }
 
 .member--links {
   list-style: none;
   margin: 0;
   padding: 0;
-  // position: absolute;
-  // top: 0;
-  // left: 0;
-  // right: 0;
-  // height: (160/$base-font-size)*1em;
-  // overflow: auto;
-  // display: none;
-  // background-color: rgba($background-color, 0.8);
-  // :hover > &, :focus > & {
-  //   display: block;
-  // }
   li {
     display: block;
     float: left;

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -12,7 +12,28 @@
   }
 }
 
-.member {
+.member:target {
+  margin-top: (70/$base-font-size)*-1em;
+  &::before {
+    content: ' ';
+    display: block;
+    height: (70/$base-font-size)*1em;
+    width: 1px;
+    background: transparent;
+  }
+  .member--wrapper {
+    border: 4px solid $brand-color;
+    box-sizing: border-box;
+    transform: scale(1.1) rotate(-2deg);
+    transform-origin: center center;
+    background-color: #fff;
+    a.website::before {
+      height: (152/$base-font-size)*1em;
+    }
+  }
+}
+
+.member--wrapper {
   padding: 0;
   position: relative;
   width: (160/$base-font-size)*1em;
@@ -62,16 +83,6 @@
     }
     &:hover::after, &:focus::after {
       display: block;
-    }
-  }
-  &:target {
-    border: 4px solid $brand-color;
-    box-sizing: border-box;
-    transform: scale(1.1) rotate(-2deg);
-    transform-origin: center center;
-    background-color: #fff;
-    a.website::before {
-      height: (152/$base-font-size)*1em;
     }
   }
 }
@@ -206,10 +217,15 @@
     transition-property: max-width;
   }
   a:hover ~ &, a:focus ~ &,
-  img:hover ~ &, .member[aria-expanded="true"] & {
+  img:hover ~ &, .member:target &,
+  .member[aria-expanded="true"] & {
     cursor: default;
     .rest {
       max-width: 90%;
     }
+  }
+  .member:target & {
+    top: -8px;
+    right: -7px;
   }
 }

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -170,7 +170,7 @@
   line-height: 1.4em;
   color: white;
   position: absolute;
-  top: -2px;
+  top: -4px;
   left: -2px;
   right: -3px;
   pointer-events: none;

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -193,7 +193,7 @@
     &.volunteer {
       background-color: $yellow-color;
     }
-    &.blogger {
+    &.writer {
       background-color: $lilac-color;
     }
   }

--- a/css/main.scss
+++ b/css/main.scss
@@ -17,6 +17,10 @@ $text-color:       #232323;
 $background-color: #fafafa;
 $brand-color:      #E0644F;
 
+$blue-color:       #5F9ADE;
+$green-color:      #96BA71;
+$lilac-color:      #A97FCE;
+$yellow-color:     #F7BC5B;
 $grey-color:       #828282;
 $grey-color-light: lighten($grey-color, 40%);
 $grey-color-dark:  darken($grey-color, 25%);

--- a/css/main.scss
+++ b/css/main.scss
@@ -7,6 +7,7 @@
 
 // Our variables
 $base-font-family: 'Asap', sans-serif;
+$mono-font-family: 'Courier New', Courier, mono;
 $base-font-size:   18;
 $small-font-size:  $base-font-size * 0.875px;
 $base-line-height: 1.5;


### PR DESCRIPTION
This PR implements the badges we’ve discussed thus far, cleans up the `.members`-specific stylesheet, and tweaks the appearance of highlighted (read: `:target`ed) members. Badges are added to a member‘s profile by defining a `roles` array like so:
```yaml
name: John Wick
# other member data
roles:
  - contributor
  - writer
  - volunteer
```

So far, the three roles used in the example above are the only ones that have colors assigned. Other roles will get a dark gray background as a fallback. More colors can be defined as further roles are adopted.

Preview:
![preview of badge appearance and behavior](https://cl.ly/3p2I3G3U3031/Screen%20Recording%202017-04-22%20at%2012.04%20AM.gif)

---

The meanings of these roles should be discussed. My proposal is as follows:
- `contributor` — members who have made contributions to devanooga projects (besides adding their member information to this repo). See: contributing software, hardware or project leadership/management to official devanooga projects. Contributing to the setup of a ham repeater, for example, would earn you this badge.
- `writer` — this one is obvious.
- `volunteer` — members who help out in more logistical, clerical, or otherwise not project-specific ways. Maybe you help coordinate devanooga events, or are part of the cleanup crew during/after a hackathon.

I’d like for us to discuss this a bit here before this PR gets merged, to be sure we’re all on the same page and any useful badges I may be missing are covered. Community input would be especially helpful here.