### PR TITLE
Reorder menu items

### DIFF
--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -2,8 +2,8 @@
 title: Blog
 permalink: /blog/
 layout: page
-menu_group: 2
-menu_sort: 3
+menu_group: 1
+menu_sort: 2
 ---
 
 {% for page in site.posts %}

--- a/_pages/channels.html
+++ b/_pages/channels.html
@@ -3,7 +3,7 @@ layout: default
 title: Channels
 permalink: /channels/
 menu_group: 1
-menu_sort: 1
+menu_sort: 4
 ---
 
 {% for page in site.pages %}

--- a/_pages/coc.md
+++ b/_pages/coc.md
@@ -3,7 +3,7 @@ layout: page
 title: Code of Conduct
 permalink: /code-of-conduct/
 menu_group: 2
-menu_sort: 1
+menu_sort: 2
 ---
 
 ## tl;dr

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -3,7 +3,7 @@ layout: default
 title: Contact Us
 permalink: /contact/
 menu_group: 2
-menu_sort: 2
+menu_sort: 3
 ---
 
 

--- a/_pages/members.html
+++ b/_pages/members.html
@@ -4,7 +4,7 @@ layout_modifier: wide
 title: Members
 permalink: /members/
 menu_group: 1
-menu_sort: 3
+menu_sort: 1
 ---
 <p class="member_intro"><strong>We welcome tinkerers of every stripe and background!</strong> You don’t have to be a developer to join our community. Just bring your curiosity and enthusiasm for technology. To be featured on this page, <a href="https://github.com/devanooga/devanooga.github.io#submitting-your-member-profile">follow the instructions</a> on this website’s readme.</p>
 

--- a/_pages/slack.md
+++ b/_pages/slack.md
@@ -3,7 +3,7 @@ layout: default
 title: Join us
 permalink: /slack/
 menu_group: 1
-menu_sort: 4
+menu_sort: 3
 ---
 
 


### PR DESCRIPTION
This PR reorders the navigation menu items to what I think better reflects current priorities and existing content:

Full menu:
![screenshot of full menu](https://cl.ly/362u0i0A441m/Image%202017-05-10%20at%209.29.05%20PM.png)

Partially-obstructed menu:
![screenshot of partially-obstructed menu](https://cl.ly/0X0L0w2P2M3L/Image%202017-05-10%20at%209.30.25%20PM.png)