### PR TITLE
Load donate section dynamically

### DIFF
--- a/_sass/_donorbox.scss
+++ b/_sass/_donorbox.scss
@@ -1,5 +1,5 @@
 .dbox-donation-section {
-    display: none;
+    display: block;
 }
 
 .dbox-donation-container {

--- a/_sass/_donorbox.scss
+++ b/_sass/_donorbox.scss
@@ -1,7 +1,3 @@
-.dbox-donation-section {
-    display: block;
-}
-
 .dbox-donation-container {
     text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -1,8 +1,6 @@
 ---
 layout: default
 ---
-<script src="/js/index.js"></script>
-
 <header>
   <p>We are an online community of tinkerers in and around Chattanooga, TN.</p>
   <p><a href="/slack/">Join us on Slack.</a></p>
@@ -17,11 +15,13 @@ layout: default
   <h2>Our resources</h2>
   <p>Our main resource is a <a href="/slack/">Slack Team</a>, where technologists from all around the region come together to share ideas, troubleshoot their projects, learn new things, or just hang out. We keep a relaxed atmosphere in there, but we do expect you to heed our <a href="/code-of-conduct/">Code of Conduct</a> (CoC). If you have any questions about the CoC, feel free to <a href="/contact/">use our contact form</a> to get in touch. You can also ask us on Slack, either publicly in the #general channel, or privately to any of the admins.</p>
 </section>
-<section class="dbox-donation-section">
-  <h2>Donate to devanooga</h2>
-  <p>devanooga is looking to work on many fun projects and events, become a donor today!</p>
-  <div class="dbox-donation-container">
-    <script src="https://donorbox.org/install-popup-button.js" type="text/javascript" defer></script>
-    <a class="dbox-donation-button" href="https://donorbox.org/donate-to-devanooga" style="" >Donate</a>
-  </div>
-</section>
+<script type="text/template" id="dbox-donation-template">
+  <section class="dbox-donation-section">
+    <h2>Donate to devanooga</h2>
+    <p>devanooga is looking to work on many fun projects and events, become a donor today!</p>
+    <div class="dbox-donation-container">
+      <a class="dbox-donation-button" href="https://donorbox.org/donate-to-devanooga" style="" >Donate</a>
+    </div>
+  </section>
+</script>
+<script type="text/javascript" src="/js/donate_section.js"></script>

--- a/js/donate_section.js
+++ b/js/donate_section.js
@@ -1,0 +1,6 @@
+(function (window, document) {
+  var section_template =
+    document.getElementById("dbox-donation-template").innerHTML;
+  document.write(section_template);
+  document.write("<script src=\"https://donorbox.org/install-popup-button.js\" type=\"text/javascript\" defer><\/script>");
+})(window, document);

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,0 @@
-window.onload = function() {
-    var sections = document.getElementsByClassName('dbox-donation-section');
-    if(sections.length > 0) {
-        sections[0].style.display = 'block';
-    }
-};


### PR DESCRIPTION
Currently, the donate section is loaded in the HMTL, hidden via CSS by default, and a bit of JS changes its `style` attribute to reveal it. This PR loads the markup as a template and the JS injects it into the DOM. This prevents the section from ever being consumed as part of the document flow by any client not running JavaScript and which doesn’t respect CSS `display: none` rules (text-only browsers, scrapers).