### PR TITLE
Skip to content link

### DIFF
--- a/_includes/skip-to-content-link.html
+++ b/_includes/skip-to-content-link.html
@@ -1,0 +1,1 @@
+<a href="#main-content" tabindex="1" class="hidden-yet-focusable">Skip to content</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,8 +2,9 @@
 <html>
   {% include head.html %}
   <body>
+    {% include skip-to-content-link.html %}
     {% include header.html %}
-    <main class="wrapper {{page.layout_modifier}}">
+    <main id="main-content" class="wrapper {{page.layout_modifier}}">
       {{ content }}
     </main>
     {% include footer.html %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -26,7 +26,6 @@ body {
     color: $text-color;
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
-    padding-top: (50/$base-font-size)*1em;
     * {
         transition-duration: 0.3s;
         transition-timing-function: ease;

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,5 +1,5 @@
 .header {
-  position: fixed;
+  position: relative;
   top: 0;
   z-index: 2;
   height: (50/$base-font-size)*1em;

--- a/_sass/_hidden-yet-focusable.scss
+++ b/_sass/_hidden-yet-focusable.scss
@@ -1,0 +1,21 @@
+.hidden-yet-focusable {
+  display: block;
+  box-sizing: border-box;
+  height: 0;
+  background-color: $yellow-color;
+  color: $text-color;
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+  transition-property: height, padding, border-width;
+  &:focus, &:active {
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 2;
+    height: 2.6em;
+    padding: 0.5em 0;
+    outline: none;
+  }
+}

--- a/_sass/_hidden-yet-focusable.scss
+++ b/_sass/_hidden-yet-focusable.scss
@@ -2,6 +2,7 @@
   display: block;
   box-sizing: border-box;
   height: 0;
+  overflow: hidden;
   background-color: $yellow-color;
   color: $text-color;
   font-weight: bold;

--- a/_sass/_logo.scss
+++ b/_sass/_logo.scss
@@ -36,4 +36,16 @@
     right: 100%;
     height: 50px;
   }
+
+  a:focus &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border: 4px solid $text-color;
+    box-sizing: border-box;
+  }
 }

--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -13,11 +13,11 @@
 }
 
 .member:target {
-  margin-top: (70/$base-font-size)*-1em;
+  margin-top: (30/$base-font-size)*-1em;
   &::before {
     content: ' ';
     display: block;
-    height: (70/$base-font-size)*1em;
+    height: (30/$base-font-size)*1em;
     width: 1px;
     background: transparent;
   }

--- a/css/main.scss
+++ b/css/main.scss
@@ -61,5 +61,6 @@ $on-laptop:        800px;
         "members",
         "logo",
         "donorbox",
-        "post"
+        "post",
+        "hidden-yet-focusable"
 ;


### PR DESCRIPTION
This PR adds a handy _Skip to content_ link at the top of every page that remains hidden until users tab to it (à la GitHub’s _Skip to content_ link). It also gives the logo a `:focus` state, since it is otherwise impossible to tell visually that it is focused.

Sample:
![screencast of behavior](https://cl.ly/1i470l3P3m1i/Screen%20Recording%202017-05-13%20at%2007.58%20PM.gif)