### PR TITLE
Fix small spacing issue in the members page header

### DIFF
--- a/_pages/members.html
+++ b/_pages/members.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-layout_modifier: wide
+layout_modifier: wrapper--members_page wide
 title: Members
 permalink: /members/
 menu_group: 1

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -51,4 +51,9 @@ footer {
     &.wide {
         max-width: (1280/$base-font-size)*1em;
     }
+    &.wrapper--members_page {
+        header {
+            margin-bottom: 1.6em;
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a small spacing issue I noticed while taking a look at #111.

Currently, our members page shows no space between the page heading and the page content:
![screenshot of shitty header spacing](https://cl.ly/1c240n3D3139/Image%202017-06-01%20at%208.02.08%20PM.png)

This PR fixes it like so:
![screenshot of fixed header spacing](https://cl.ly/3Z431J3e0e34/Image%202017-06-01%20at%208.02.58%20PM.png)