### PR TITLE
Resolution of Flash of Unstyled Content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
   <link rel="shortcut icon" href="/images/favicon.png"> 
+  {% include google-fonts.html %}
+  {% include stylesheets-header.html %}
 
   {% seo %}
 </head>

--- a/_includes/stylesheets-footer.html
+++ b/_includes/stylesheets-footer.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ "/css/footer.css" | prepend: site.baseurl }}?v={{ site.time | date_to_xmlschema }}">

--- a/_includes/stylesheets-header.html
+++ b/_includes/stylesheets-header.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ "/css/header.css" | prepend: site.baseurl }}?v={{ site.time | date_to_xmlschema }}">

--- a/_includes/stylesheets-main.html
+++ b/_includes/stylesheets-main.html
@@ -1,1 +1,0 @@
-<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?v={{ site.time | date_to_xmlschema }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,6 @@
     </main>
     {% include footer.html %}
     {% include ga.html %}
-    {% include google-fonts.html %}
-    {% include stylesheets-main.html %}
+    {% include stylesheets-footer.html %}
   </body>
 </html>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,10 +1,3 @@
----
-# Only the main Sass file needs front matter (the dashes are enough)
----
-@charset "utf-8";
-
-
-
 // Our variables
 $base-font-family: 'Asap', sans-serif;
 $mono-font-family: 'Courier New', Courier, mono;
@@ -47,24 +40,3 @@ $on-laptop:        800px;
         @content;
     }
 }
-
-
-
-// Import partials from `sass_dir` (defaults to `_sass`)
-@import
-        "base",
-        "typography",
-        "layout",
-        "syntax-highlighting",
-        "form",
-        "header",
-        "navigation",
-        "members",
-        "logo",
-        "donorbox",
-        "post",
-        "archive",
-        "hidden-yet-focusable",
-        "announcement",
-        "button"
-;

--- a/css/footer.scss
+++ b/css/footer.scss
@@ -14,7 +14,6 @@
         "donorbox",
         "post",
         "archive",
-        "hidden-yet-focusable",
         "announcement",
         "button"
 ;

--- a/css/footer.scss
+++ b/css/footer.scss
@@ -1,0 +1,20 @@
+---
+---
+@charset "utf-8";
+
+// Import partials from `sass_dir` (defaults to `_sass`)
+@import
+        "variables",
+        "syntax-highlighting",
+        "form",
+        "header",
+        "navigation",
+        "members",
+        "logo",
+        "donorbox",
+        "post",
+        "archive",
+        "hidden-yet-focusable",
+        "announcement",
+        "button"
+;

--- a/css/header.scss
+++ b/css/header.scss
@@ -1,0 +1,11 @@
+---
+---
+@charset "utf-8";
+
+// Import partials from `sass_dir` (defaults to `_sass`)
+@import
+        "variables",
+        "base",
+        "typography",
+        "layout",
+;

--- a/css/header.scss
+++ b/css/header.scss
@@ -8,4 +8,5 @@
         "base",
         "typography",
         "layout",
+        "hidden-yet-focusable"
 ;


### PR DESCRIPTION
Including all of the stylesheets at the bottom, right before the end of the body tag, is causing a very noticeable flash of unstyled content. 

I came up with a workaround. Include the Google fonts stylesheet in the header. Also, split up the page stylesheet into a header and footer stylesheet. The header stylesheet contains the absolute necessary styles to render the pages in an acceptable manner. The footer contains "unnecessary" styles.

Example of issue on devanooga.com: https://youtu.be/ZoHDke_UWRQ
![fouc](https://user-images.githubusercontent.com/42041/27669903-70e8c79c-5c57-11e7-957a-f8285bf06620.gif)


Example with fix in local dev: https://youtu.be/97DfJKJsRWo
![local-dev-with-fix](https://user-images.githubusercontent.com/42041/27669919-87de36bc-5c57-11e7-8c8c-e1d874415a8c.gif)
