### PR TITLE
add more resources to truebeginners channel page

### DIFF
--- a/_pages/channels/truebeginners.md
+++ b/_pages/channels/truebeginners.md
@@ -16,8 +16,12 @@ This channel is *usually* for less language-specific questions (eg: learning abo
 
 [DevTube](https://dev.tube/) - A big collection of developer videos
 
-[Git Tutorial](https://try.github.io/) - 15 minute Git tutorial for true Git newbies
+[Git Resources](https://try.github.io/) - Resources to learn Git, by reading or by doing
 
 [Hackterms](https://www.hackterms.com/) - A crowdsourced dictionary of coding terms
 
 [OpenLibra](https://openlibra.com/) - Free educational eBooks
+
+[Flight rules for Git](https://github.com/k88hudson/git-flight-rules/) - Flight Rules: A guide for astronauts (now, programmers using Git) about what to do when things go wrong
+
+[Do What You Love](https://github.com/dwyl/start-here/) - A Quick-start Guide for people that want to Do What You Love


### PR DESCRIPTION
add links to Git Flight Rules and Do What You Love to the truebeginners channel page, adjust description for try.github.io since it no longer matches the link