### PR TITLE
Add echolink information to #ham channel page

### DIFF
--- a/_pages/channels/ham.md
+++ b/_pages/channels/ham.md
@@ -20,7 +20,7 @@ Discussions about Amateur Radio in the Chattanooga area.
 
 [CARC](http://w4am.net) - Chattanooga Amateur Radio Club
 
-[P5 Preparedness](http://www.p5preparedness.com/index.php/56-p5-amateur-radio-club) - A new club focused on new hams and emergency preparedness.
+devanooga - Official devanooga radio club, `W3DEV`
 
 ### APRS
 
@@ -33,6 +33,25 @@ Discussions about Amateur Radio in the Chattanooga area.
 [Mobilinkd](https://store.mobilinkd.com) - Bluetooth TNC for connecting your phone to your radio. Great for APRS and other digital modes.
 
 ### Digital Radio
+
+#### Echolink
+
+The devanooga radio club (`W3DEV`) has an official Echolink node, thanks to
+hardware donations from
+[@strangewill](http://localhost:4000/members/#strangewill)!
+
+devanooga echolink node: W3DEV-L
+
+Echolink clients:
+- Windows: [Echolink official client](http://echolink.org/download.htm)
+- Linux: [Qtel](https://www.svxlink.org/) - (for Arch, install qtel-git from AUR)
+- macOS: [EchoHam](http://echomac.sourceforge.net/) - (old, but it works)
+- Android: [Echolink for Android](https://play.google.com/store/apps/details?id=org.echolink.android)
+- iOS: [Echolink for iOS](https://apps.apple.com/app/id350688562)
+
+If it's your fist time using echolink, you have to install the client for your
+preferred platform, sign in with your callsign and make up a password, then go
+here to validate: http://echolink.org/validation/
 
 #### DMR
 


### PR DESCRIPTION
Adds echolink info (node, and client information), and also removes `P5 Preparedness` amateur radio club, as it appears to be defunct.