### PR TITLE
Move Folding@Home into footer, update hacknight announcement

### DIFF
--- a/_includes/announcement.html
+++ b/_includes/announcement.html
@@ -1,16 +1,3 @@
-<aside class="announcement urgent">
-    <h2>Assist in the race to the cure for COVID-19 by Folding At Home!</h2>
-    <p>
-        Devanooga is proud to announce that its members are using their spare compute for Folding@home. Folding@home is a distributed computing project for performing molecular dynamics simulations of protein dynamics. By joining us in the Folding@home project, you are contributing to the potential discovery of cures and/or treatments for COVID-19.
-    </p>
-    <p>
-        Devanooga Team ID: <a href="https://stats.foldingathome.org/team/249819" title="Devanooga Folding at Home team">249819</a>
-    </p>
-    <p>
-        <a href="https://foldingathome.org" title="Fold with Devanooga" class="button button--blue button--block">Fold with Devanooga</a>
-    </p>
-</aside>
-
 <aside class="announcement">
     <h2>There is no live stream currently scheduled, keep an eye out for an announcement in the future.</h2>
     <p>
@@ -22,10 +9,11 @@
 </aside>
 
 <aside class="announcement">
-    <h2>Our next hacknight is currently postponed until further notice while we test out some online hacknights on our Discord due to the COVID-19 situation, stay tuned for more announcements.</h2>
+    <h2>The devanooga hacknight is held every other Wednesday from 6 to 9pm at <a href="https://chattanoogacoworking.com">Workhorse</a>. </h2>
     <p>
-        The devanooga hacknight will held every other Monday from 6 to 9pm. <strong>All experience levels are welcome for projects, pizza, and banter.</strong> Just bring your enthusiasm!
-    </p>
+        All experience levels are welcome for projects, pizza, and banter. Just bring your enthusiasm! For exact dates and to RSVP to the next hacknight please visit the #hacknight channel on <a href="/slack/">our Slack</a>. Please make sure you are fully vaccinated against COVID-19 before attending.
+	<p>
+	</p>
     <p>
         <a href="https://calendar.google.com/calendar/embed?src=devanooga.com_gfjpavg0j06gbkibo7pjr9d2jg%40group.calendar.google.com&ctz=America/New_York" title="View calendar" class="button button--blue button--block button--calendar">Add hacknight to your calendar</a>
     </p>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
 <footer id="footer" class="footer wrapper">
   <hr>
-  <p>You can follow us on <a href="https://twitter.com/{{ site.twitter:username}}">Twitter</a>, view our projects on <a href="https://github.com/{{site.github_username }}">Github</a>, and view our <a href="https://brand-guide.devanooga.com/">Brand Guide</a>.</p>
+  <p>You can follow us on <a href="https://twitter.com/{{ site.twitter:username}}">Twitter</a>, view our projects on <a href="https://github.com/{{site.github_username }}">Github</a>, join our <a href=https://stats.foldingathome.org/team/249819>Folding@Home</a> team, and view our <a href="https://brand-guide.devanooga.com/">Brand Guide</a>.</p>
 </footer>


### PR DESCRIPTION
Removed the Folding@Home box from the announcement page and instead put a link to our team into the footer. Updated the hacknight announcement to reflect the current hacknight state.