### PR TITLE
Add Netlify hook to deploy nightly

### DIFF
--- a/.github/workflows/nightly_deploy.yml
+++ b/.github/workflows/nightly_deploy.yml
@@ -1,0 +1,15 @@
+name: Netlify Nightly Deploy
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+
+jobs:
+  build:
+    name: Call Netlify build hook
+    runs-on: ubuntu-latest
+    with:
+      netlify_build_hook: ${{ secrets.NETLIFY_BUILD_HOOK }}
+    steps:
+      - name: Curl request
+        run: curl -X POST -d '{}' "https://api.netlify.com/$NETLIFY_BUILD_HOOK"


### PR DESCRIPTION
This will deploy the `master` branch to Netlify at 7AM UTC every day.
This will allow us to schedule blog posts without worrying about triggering deploys at the correct time.